### PR TITLE
Avg brain mapping test fixed

### DIFF
--- a/iELVis/TEST_SCRIPTS/check_iELVisInstall.m
+++ b/iELVis/TEST_SCRIPTS/check_iELVisInstall.m
@@ -76,7 +76,7 @@ cfgOut=plotPialSurf('PT001',cfg);
 
 %% Test avg brain mapping
 disp('Checking mapping to average brain on demo data PT001...');
-[avgCoords, elecNames, isLeft]=pial2AvgBrain('PT001',[]);
+[avgCoords, elecNames, isLeft]=sub2AvgBrain('PT001',[]);
 
 
 %% Test assigning electrodes to atlas areas


### PR DESCRIPTION
check_iELVisInstall.m was calling sub2AvgBrain.m by its old name
pial2AvgBrain.m